### PR TITLE
Fix: Align SSE streaming response format with client expectations

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -149,7 +149,7 @@ export async function POST(request: NextRequest) {
 
                 // Send the text chunk to the client
                 controller.enqueue(
-                  encoder.encode(`data: ${JSON.stringify({ text })}\n\n`)
+                  encoder.encode(`data: ${JSON.stringify({ type: 'content', content: text })}\n\n`)
                 );
               }
             } else if (event.type === 'message_stop') {
@@ -168,10 +168,15 @@ export async function POST(request: NextRequest) {
                 data: { updatedAt: new Date() },
               });
 
-              // Send completion signal
+              // Send completion signal with messageId
+              const savedMessage = await prisma.message.findFirst({
+                where: { conversationId: conversation.id },
+                orderBy: { createdAt: 'desc' },
+              });
+
               controller.enqueue(
                 encoder.encode(
-                  `data: ${JSON.stringify({ done: true, conversationId: conversation.id })}\n\n`
+                  `data: ${JSON.stringify({ type: 'done', messageId: savedMessage?.id, conversationId: conversation.id })}\n\n`
                 )
               );
             }


### PR DESCRIPTION
## Summary
- Fixed streaming response format mismatch between server and client
- Chat messages now display in real-time word-by-word as intended

## Root Cause
The server was sending SSE events with format `{ text: "..." }` and `{ done: true }`, but the client's ChatInterface component was expecting `{ type: 'content', content: "..." }` and `{ type: 'done', messageId: "..." }`. This caused all streaming chunks to be silently ignored.

## Solution
- Updated text chunk format: `{ text }` → `{ type: 'content', content: text }`
- Updated completion signal: `{ done, conversationId }` → `{ type: 'done', messageId, conversationId }`
- Added query to retrieve saved message ID on stream completion for proper tracking

## Testing
- [x] Tested in development mode - streaming works correctly
- [x] Verified messages appear word-by-word in real-time
- [x] Confirmed message IDs are properly tracked
- [x] No console errors

## Files Changed
- `app/api/chat/route.ts` - Updated SSE response format to match client expectations

🤖 Generated with [Claude Code](https://claude.ai/code)